### PR TITLE
switch from using openssl for signing to rsa

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0"
-base64 = "0.12"
-openssl = "0.10"
+base64 = "0.13"
+rsa = "0.3"
+sha2 = "0.9.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod package;
 #[cfg(test)]
 mod test;
 
-use openssl::error::ErrorStack;
+use rsa::errors::Error as RSAError;
 use std::io;
 use thiserror::Error;
 
@@ -14,10 +14,13 @@ pub enum Error {
     FailedToLoadKey(#[source] io::Error),
     #[error("Failed to package file: {0}")]
     FailedToPackage(#[source] io::Error),
-    #[error("Key could not be parsed by openssl: {0}")]
-    InvalidKey(#[source] ErrorStack),
+    #[error("Key could not be parsed")]
+    InvalidKey,
+    #[error("Keyfile {0} not found")]
+    KeyNotFound(PathBuf),
     #[error("Failed to sign package: {0}")]
-    SignatureFailed(#[source] ErrorStack),
+    SignatureFailed(#[source] RSAError),
 }
 
 pub use package::sign_package;
+use std::path::PathBuf;

--- a/src/package.rs
+++ b/src/package.rs
@@ -4,31 +4,46 @@ use std::path::Path;
 
 use crate::Error;
 use base64::encode;
-use openssl::hash::MessageDigest;
-use openssl::pkey::{PKey, Private};
-use openssl::sign::Signer;
+use rsa::{padding::PaddingScheme, Hash, RSAPrivateKey};
+use sha2::{Digest, Sha512};
 
 pub fn sign_package(key_path: &Path, file_path: &Path) -> Result<String, Error> {
     let package_file = File::open(file_path).map_err(Error::FailedToPackage)?;
-    let key = read_to_string(key_path).map_err(Error::FailedToPackage)?;
+    let raw_key = read_to_string(key_path).map_err(|_| Error::KeyNotFound(key_path.into()))?;
+    let key = decode_private_key(&raw_key)?;
 
     let buf_read = BufReader::new(package_file);
-    let key_pair = PKey::private_key_from_pem(key.as_bytes()).map_err(Error::InvalidKey)?;
-    sign(buf_read, &key_pair)
+    sign(buf_read, &key)
 }
 
-fn sign(mut package: impl Read, key: &PKey<Private>) -> Result<String, Error> {
-    let mut signer = Signer::new(MessageDigest::sha512(), &key).map_err(Error::InvalidKey)?;
-    copy(&mut package, &mut signer).map_err(Error::FailedToPackage)?;
-
-    let signature = signer.sign_to_vec().map_err(Error::SignatureFailed)?;
+fn sign(mut package: impl Read, key: &RSAPrivateKey) -> Result<String, Error> {
+    let mut hasher = Sha512::new();
+    copy(&mut package, &mut hasher).map_err(Error::FailedToPackage)?;
+    let signature = key
+        .sign(
+            PaddingScheme::new_pkcs1v15_sign(Some(Hash::SHA2_512)),
+            &hasher.finalize(),
+        )
+        .map_err(Error::SignatureFailed)?;
 
     Ok(encode(&signature))
+}
+
+fn decode_private_key(key_data: &str) -> Result<RSAPrivateKey, Error> {
+    let der_encoded = key_data
+        .split('\n')
+        .filter(|line| !line.starts_with("-"))
+        .fold(String::with_capacity(1024), |mut data, line| {
+            data.push_str(line);
+            data
+        });
+    let der_bytes = base64::decode(&der_encoded).map_err(|_| Error::InvalidKey)?;
+    RSAPrivateKey::from_pkcs8(&der_bytes).map_err(|_| Error::InvalidKey)
 }
 
 #[test]
 fn test_sign() {
     use crate::test::*;
-    let key = PKey::private_key_from_pem(PEM_PRIVATE_KEY).unwrap();
+    let key = decode_private_key(PEM_PRIVATE_KEY).unwrap();
     assert_eq!(EXPECTED_SIGNATURE, sign(TEST_CONTENT, &key).unwrap());
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-pub static PEM_PRIVATE_KEY: &'static [u8] = b"-----BEGIN PRIVATE KEY-----
+pub static PEM_PRIVATE_KEY: &'static str = "-----BEGIN PRIVATE KEY-----
 MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDM8e7XeoNRhzGT
 K/pXtXq4W52J62Yhsv6cldWP3GhiMIxp3jiKuKIbgQVR5XBYd9iAzHmsFz6KczwI
 95zZkL66VTw/YyHKdxFpNw4Z7RfmN/xUKqRGhJzO8NouampSUFEDeUhSPW6Rb0mg


### PR DESCRIPTION
having openssl as a dependency is a pain when it comes to trying to make portable binaries