### PR TITLE
pass package content as reader instead of by path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nextcloud_appsignature"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Christoph Wurst <christoph@winzerhof-wurst.at>"]
 description = "Library to sign Nextcloud apps"
 readme = "README.md"


### PR DESCRIPTION
this allows signing packages from other sources than the filesystem.

Could also do this for the key, but I'm not sure how valid the use case where you don't have the key stored in the filesystem.